### PR TITLE
Reference keyword options in documentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Let’s define the FSM instance
 
 ```elixir
 defmodule MyFSM do
-  @fsm """
+  @plantuml """
   [*] --> s1 : to_s1
   s1 --> s2 : to_s2
   s1 --> s3 : to_s3
@@ -59,7 +59,13 @@ defmodule MyFSM do
   s3 --> [*] : ok
   """
 
-  use Finitomata, @fsm
+  use Finitomata, fsm: @plantuml, syntax: Finitomata.PlantUML
+  ## or uncomment lines below for Mermaid syntax
+  # @mermaid """
+  # s1 --> |to_s2| s2
+  # s1 --> |to_s3| s3
+  # """
+  # use Finitomata, fsm: @mermaid, syntax: Finitomata.Mermaid
 
   def on_transition(:s1, :to_s2, event_payload, state_payload),
     do: {:ok, :s2, state_payload}


### PR DESCRIPTION
Hello,

I've noticed that example in documentation is not working (outdated?).
It errors out with
```
** (SyntaxError) lib/finitomata.ex:1: malformed FSM transition, expected `from --> |event| to`
```

Looks like that now one must supply `syntax` attribute if they want PlantUML spec to work. Otherwise Mermaid is used by default.

Anyway, here's a documentation fix. 