### PR TITLE
Attach error to state.

### DIFF
--- a/lib/finitomata.ex
+++ b/lib/finitomata.ex
@@ -443,7 +443,7 @@ defmodule Finitomata do
           end
         else
           err ->
-            state_with_error = struct(state, error: err)
+            state = %State{state | error: err}
             cond do
               event in @__config_soft_events__ ->
                 Logger.debug("[⚐⥯] transition softly failed " <> inspect(err))

--- a/lib/finitomata.ex
+++ b/lib/finitomata.ex
@@ -447,17 +447,17 @@ defmodule Finitomata do
             cond do
               event in @__config_soft_events__ ->
                 Logger.debug("[⚐⥯] transition softly failed " <> inspect(err))
-                {:noreply, state_with_error}
+                {:noreply, state}
 
               @__config__[:fsm]
               |> Transition.allowed(state.current, event)
               |> Enum.all?(&(&1 in @__config__[:ensure_entry])) ->
-                {:noreply, state_with_error, {:continue, {:transition, event_payload({event, payload})}}}
+                {:noreply, state, {:continue, {:transition, event_payload({event, payload})}}}
 
               true ->
                 Logger.warn("[⚐⥯] transition failed " <> inspect(err))
-                safe_on_failure(event, payload, state_with_error)
-                {:noreply, state_with_error}
+                safe_on_failure(event, payload, state)
+                {:noreply, state}
             end
         end
       end

--- a/lib/finitomata.ex
+++ b/lib/finitomata.ex
@@ -23,6 +23,10 @@ defmodule Finitomata do
     @typedoc "The payload that has been passed to the FSM instance on startup"
     @type payload :: any()
 
+    @typedoc "The map that holds last error which happened on transition (at given state and event)."
+    @type last_error ::
+            %{state: Transition.state(), event: Transition.event(), error: any()} | nil
+
     @typedoc "The internal representation of the FSM state"
     @type t :: %{
             __struct__: State,
@@ -30,9 +34,9 @@ defmodule Finitomata do
             payload: payload(),
             timer: non_neg_integer(),
             history: [Transition.state()],
-            error: any()
+            last_error: last_error()
           }
-    defstruct payload: %{}, current: :*, timer: false, history: [], error: nil
+    defstruct payload: %{}, current: :*, timer: false, history: [], last_error: nil
   end
 
   @typedoc "The payload that can be passed to each call to `transition/3`"
@@ -443,7 +447,8 @@ defmodule Finitomata do
           end
         else
           err ->
-            state = %State{state | error: err}
+            state = %State{state | last_error: %{state: state.current, event: event, error: err}}
+
             cond do
               event in @__config_soft_events__ ->
                 Logger.debug("[⚐⥯] transition softly failed " <> inspect(err))

--- a/test/finitomata_test.exs
+++ b/test/finitomata_test.exs
@@ -10,7 +10,7 @@ defmodule FinitomataTest do
   def setup_all do
   end
 
-  alias Finitomata.Test.{Auto, Callback, EnsureEntry, Log, Soft, Timer}
+  alias Finitomata.Test.{Auto, Callback, EnsureEntry, ErrorAttach, Log, Soft, Timer}
 
   test "exported types" do
     defmodule StatesTest do
@@ -147,5 +147,16 @@ defmodule FinitomataTest do
     Process.sleep(200)
     assert %Finitomata.State{current: :started} = Finitomata.state("SoftFSM")
     assert Finitomata.alive?("SoftFSM")
+  end
+
+  test "error attached" do
+    start_supervised(Finitomata.Supervisor)
+    fsm = "ErrorFSM"
+    Finitomata.start_fsm(ErrorAttach, fsm, %{foo: :bar})
+
+    assert capture_log(fn ->
+             Finitomata.transition(fsm, {:start, nil})
+             Process.sleep(200)
+           end) =~ "[failure] {:error, \"Test error\"}"
   end
 end

--- a/test/finitomata_test.exs
+++ b/test/finitomata_test.exs
@@ -154,9 +154,14 @@ defmodule FinitomataTest do
     fsm = "ErrorFSM"
     Finitomata.start_fsm(ErrorAttach, fsm, %{foo: :bar})
 
-    assert capture_log(fn ->
-             Finitomata.transition(fsm, {:start, nil})
-             Process.sleep(200)
-           end) =~ "[failure] {:error, \"Test error\"}"
+    captured_log =
+      capture_log(fn ->
+        Finitomata.transition(fsm, {:start, nil})
+        Process.sleep(200)
+      end)
+
+    assert captured_log =~ "[failure] {:error, \"Test error\"}"
+    assert captured_log =~ "[failure] state: :idle"
+    assert captured_log =~ "[failure] event: :start"
   end
 end

--- a/test/support/modules.ex
+++ b/test/support/modules.ex
@@ -162,6 +162,5 @@ defmodule Finitomata.Test.ErrorAttach do
   @impl Finitomata
   def on_failure(_event, _payload, state) do
     Logger.debug("[failure] " <> inspect(state.error))
-    :ok
   end
 end

--- a/test/support/modules.ex
+++ b/test/support/modules.ex
@@ -144,3 +144,24 @@ defmodule Finitomata.Test.Soft do
     {:error, :not_allowed}
   end
 end
+
+defmodule Finitomata.Test.ErrorAttach do
+  @moduledoc false
+
+  @fsm """
+  idle --> |start| started
+  """
+
+  use Finitomata, fsm: @fsm, auto_terminate: true
+
+  @impl Finitomata
+  def on_transition(:idle, :start, _payload, _state) do
+    raise "Test error"
+  end
+
+  @impl Finitomata
+  def on_failure(_event, _payload, state) do
+    Logger.debug("[failure] " <> inspect(state.error))
+    :ok
+  end
+end

--- a/test/support/modules.ex
+++ b/test/support/modules.ex
@@ -160,7 +160,9 @@ defmodule Finitomata.Test.ErrorAttach do
   end
 
   @impl Finitomata
-  def on_failure(_event, _payload, state) do
-    Logger.debug("[failure] " <> inspect(state.error))
+  def on_failure(_event, _payload, %{last_error: last_error} = _state) do
+    Logger.debug("[failure] " <> inspect(last_error.error))
+    Logger.debug("[failure] state: " <> inspect(last_error.state))
+    Logger.debug("[failure] event: " <> inspect(last_error.event))
   end
 end


### PR DESCRIPTION
When error happens on transit - it's logged on Finitomata level and "gone" afterwards (pls, correct me if I'm wrong).
I think it would be useful to "attach" transit error to FSM state. So it can be accessed and acted upon at `on_failure` callback.

Don't hesitate to decline the pull request if you don't agree with this change :)