### PR TITLE
Persistency: scaffold and default impl via protocol

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         include:
           - pair:
-              otp: 23.2.5
+              otp: 24.2
               elixir: 1.12.3
           - pair:
               otp: 25.0

--- a/lib/finitomata/persistency.ex
+++ b/lib/finitomata/persistency.ex
@@ -1,0 +1,46 @@
+defmodule Finitomata.Persistency do
+  @moduledoc """
+  The behaviour to be implemented by a persistent storage to be used
+    with `Finitomata` (pass the implementation as `persistency: Impl.Module.Name`
+    to `use Finitomate`.)
+
+  Once declared, the initial state would attempt to load the current state from
+    the storage using `load/1` funtcion which should return the `{state, payload}`
+    tuple.
+  """
+
+  alias Finitomata.{State, Transition}
+
+  @doc """
+  The function to be called from `init/1` callback upon FSM start to load the state and payload
+    from the persistent storage
+  """
+  @callback load(
+              name :: Finitomata.fsm_name(),
+              payload :: State.payload()
+            ) ::
+              State.payload()
+
+  @doc """
+  The function to be called from `on_transition/4` handler to allow storing the state
+    and payload to the persistent storage
+  """
+  @callback store(
+              name :: Finitomata.fsm_name(),
+              state :: Transition.state(),
+              payload :: State.payload()
+            ) ::
+              :ok | {:error, any()}
+  @doc """
+  The function to be called from `on_transition/4` handler on non successful
+    transition to allow storing the failed attempt to transition to the persistent storage
+  """
+  @callback store_error(
+              name :: Finitomata.fsm_name(),
+              reason :: any(),
+              payload :: State.payload()
+            ) ::
+              :ok | {:error, any()}
+
+  @optional_callbacks store_error: 3
+end

--- a/lib/finitomata/persistency/persistable.ex
+++ b/lib/finitomata/persistency/persistable.ex
@@ -1,0 +1,53 @@
+defprotocol Finitomata.Persistency.Persistable do
+  @moduledoc """
+  The protocol to be implemented for custom data to be used in pair with
+    `Finitomata.Persistency.Protocol` persistency adapter.
+
+  For that combination, one should implement the protocol for that particular
+    struct _and_ specify `Finitomata.Persistency.Protocol` as a `persistency`
+    in a call to `use Finitomata`.
+
+  ```elixir
+  use Finitomata, …, persistency: Finitomata.Persistency.Protocol
+  ```
+  """
+
+  @fallback_to_any false
+
+  @doc "Loads the entity from some external storage"
+  def load(data, name)
+
+  @doc "Persists the transitioned entity to some external storage"
+  def store(data, name, updated_data, supplemental_data)
+
+  @doc "Persists the error happened while an attempt to transition the entity"
+  def store_error(data, name, reason, supplemental_data)
+end
+
+defimpl Finitomata.Persistency.Persistable,
+  for: [
+    Any,
+    Atom,
+    BitString,
+    Float,
+    Function,
+    Integer,
+    List,
+    Map,
+    PID,
+    Port,
+    Reference,
+    Tuple
+  ] do
+  def load(data, _name) do
+    raise Protocol.UndefinedError, protocol: __MODULE__, value: data
+  end
+
+  def store(data, _name, _updated_data, _supplemental_data) do
+    raise Protocol.UndefinedError, protocol: __MODULE__, value: data
+  end
+
+  def store_error(data, _name, _reason, _supplemental_data) do
+    raise Protocol.UndefinedError, protocol: __MODULE__, value: data
+  end
+end

--- a/lib/finitomata/persistency/protocol.ex
+++ b/lib/finitomata/persistency/protocol.ex
@@ -1,0 +1,24 @@
+defmodule Finitomata.Persistency.Protocol do
+  @moduledoc """
+  Default implementation of persistency adapter that does nothing but routes
+    to the implementation of `Finitomata.Persistency.Persistable` for the data.
+  """
+  alias Finitomata.{Persistency, Persistency.Persistable}
+
+  @behaviour Persistency
+
+  @impl Persistency
+  def load(name, %_{} = data) do
+    Persistable.load(data, name)
+  end
+
+  @impl Persistency
+  def store(name, updated_data, {_, _, _, %_{} = data} = supplemental_data) do
+    Persistable.store(data, name, updated_data, supplemental_data)
+  end
+
+  @impl Persistency
+  def store_error(name, reason, {_, _, _, %_{} = data} = supplemental_data) do
+    Persistable.store_error(data, name, reason, supplemental_data)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -39,6 +39,7 @@ defmodule Finitomata.MixProject do
   defp deps do
     [
       {:nimble_parsec, "~> 1.0"},
+      {:nimble_options, "~> 0.5", runtime: false},
       {:boundary, "~> 0.4", runtime: false},
       # dev / test
       {:credo, "~> 1.0", only: [:dev, :ci]},
@@ -86,7 +87,17 @@ defmodule Finitomata.MixProject do
       source_url: "https://github.com/am-kantox/#{@app}",
       assets: "stuff/images",
       extras: ~w[README.md stuff/fsm.md stuff/compiler.md],
-      groups_for_modules: [],
+      groups_for_modules: [
+        FSM: [Finitomata],
+        Internals: [
+          Finitomata.State,
+          Finitomata.Transition
+        ],
+        Persistence: [
+          Finitomata.Persistence,
+          Finitomata.Persistence.Persistable
+        ]
+      ],
       before_closing_body_tag: &before_closing_body_tag/1
     ]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -11,5 +11,6 @@
   "makeup": {:hex, :makeup, "1.1.0", "6b67c8bc2882a6b6a445859952a602afc1a41c2e08379ca057c0f525366fc3ca", [:mix], [{:nimble_parsec, "~> 1.2.2 or ~> 1.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "0a45ed501f4a8897f580eabf99a2e5234ea3e75a4373c8a52824f6e873be57a6"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.16.0", "f8c570a0d33f8039513fbccaf7108c5d750f47d8defd44088371191b76492b0b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "28b2cbdc13960a46ae9a8858c4bebdec3c9a6d7b4b9e7f4ed1502f8159f338e7"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
+  "nimble_options": {:hex, :nimble_options, "0.5.2", "42703307b924880f8c08d97719da7472673391905f528259915782bb346e0a1b", [:mix], [], "hexpm", "4da7f904b915fd71db549bcdc25f8d56f378ef7ae07dc1d372cbe72ba950dce0"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
 }

--- a/test/finitomata_test.exs
+++ b/test/finitomata_test.exs
@@ -164,4 +164,17 @@ defmodule FinitomataTest do
     assert captured_log =~ "[failure] state: :idle"
     assert captured_log =~ "[failure] event: :start"
   end
+
+  test "persistense" do
+    start_supervised(Finitomata.Supervisor)
+    fsm = "PersistentFSM"
+
+    Finitomata.start_fsm(Finitomata.Test.Persistency, fsm, %Finitomata.Test.Persistency{
+      pid: self()
+    })
+
+    assert_receive :on_start!
+    assert_receive :on_do!
+    assert_receive :on_end
+  end
 end

--- a/test/support/persistence.ex
+++ b/test/support/persistence.ex
@@ -1,0 +1,48 @@
+defmodule Finitomata.Test.Persistency do
+  @moduledoc false
+
+  @fsm """
+  idle --> |start!| started
+  started --> |do!| done
+  """
+
+  use Finitomata, fsm: @fsm, auto_terminate: true, persistency: Finitomata.Persistency.Protocol
+
+  defstruct pid: nil
+
+  @impl Finitomata
+  def on_transition(:idle, :start!, _, %__MODULE__{pid: pid} = state) do
+    send(pid, :on_start!)
+    {:ok, :started, state}
+  end
+
+  @impl Finitomata
+  def on_transition(:started, :do!, _, %__MODULE__{pid: pid} = state) do
+    send(pid, :on_do!)
+    {:ok, :done, state}
+  end
+
+  @impl Finitomata
+  def on_transition(:done, :__end__, _, %__MODULE__{pid: pid} = state) do
+    send(pid, :on_end)
+    {:ok, :*, state}
+  end
+end
+
+defimpl Finitomata.Persistency.Persistable, for: Finitomata.Test.Persistency do
+  @moduledoc false
+  require Logger
+
+  def load(data, name) do
+    Logger.debug("[LOAD] " <> inspect({name, data}))
+    data
+  end
+
+  def store(data, name, updated_data, supplemental_data) do
+    Logger.debug("[STORE] " <> inspect({name, data, updated_data, supplemental_data}))
+  end
+
+  def store_error(data, name, reason, supplemental_data) do
+    Logger.debug("[STORE ERROR] " <> inspect({name, data, reason, supplemental_data}))
+  end
+end


### PR DESCRIPTION
#33 

The reason behind this implementation: to preserve the state between FSM crashes.