### PR TITLE
Enhance the syntax checker to display better error message

### DIFF
--- a/lib/finitomata.ex
+++ b/lib/finitomata.ex
@@ -42,7 +42,12 @@ defmodule Finitomata do
     ],
     syntax: [
       required: false,
-      type: {:or, [{:in, [:flowchart, :state_diagram]}, {:custom, Finitomata, :behaviour, [Finitomata.Parser]}]},
+      type:
+        {:or,
+         [
+           {:in, [:flowchart, :state_diagram]},
+           {:custom, Finitomata, :behaviour, [Finitomata.Parser]}
+         ]},
       default: :flowchart,
       doc: "The FSM dialect parser to convert the declaration to internal FSM representation."
     ],

--- a/lib/finitomata.ex
+++ b/lib/finitomata.ex
@@ -42,7 +42,7 @@ defmodule Finitomata do
     ],
     syntax: [
       required: false,
-      type: {:or, [{:in, [:flowchart, :state_diagram]}, {:custom, Finitomata, :behaviour, []}]},
+      type: {:or, [{:in, [:flowchart, :state_diagram]}, {:custom, Finitomata, :behaviour, [Finitomata.Parser]}]},
       default: :flowchart,
       doc: "The FSM dialect parser to convert the declaration to internal FSM representation."
     ],


### PR DESCRIPTION
A small change to add missing parameter to syntax checker

Now, the error message is more clear

(NimbleOptions.ValidationError) expected :syntax option to match at least one given type, but didn't match any. Here are the reasons why it didn't match each of the allowed types:

  * invalid value for :syntax option: The module specified ‹Ray.Vm› does not implement requested callbacks ‹[validate: 1, parse: 1, lint: 1]›
  * invalid value for :syntax option: expected one of [:flowchart, :state_diagram], got: Ray.Vm

Stacktrace:
  │ lib/ray/vm.ex:6: (module)

