### PR TITLE
`assert_transition/5` + `assert_path/?`

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,7 +1,10 @@
 locals_without_parens = [
   assert_payload: 1,
   assert_state: 1,
+  assert_transition: 3,
+  assert_transition: 4,
   assert_transition: 5,
+  setup_finitomata: 1,
   test_path: 5,
   test_path: 6,
   test_path: 7

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -4,8 +4,12 @@ locals_without_parens = [
   assert_transition: 3,
   assert_transition: 4,
   assert_transition: 5,
+  init_finitomata: 3,
+  init_finitomata: 4,
   init_finitomata: 5,
   setup_finitomata: 1,
+  test_path: 2,
+  test_path: 3,
   test_path: 5,
   test_path: 6,
   test_path: 7

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -4,6 +4,7 @@ locals_without_parens = [
   assert_transition: 3,
   assert_transition: 4,
   assert_transition: 5,
+  init_finitomata: 5,
   setup_finitomata: 1,
   test_path: 5,
   test_path: 6,

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,7 +1,10 @@
 locals_without_parens = [
+  assert_payload: 1,
   assert_state: 1,
   assert_transition: 5,
-  assert_transition: 6
+  test_path: 5,
+  test_path: 6,
+  test_path: 7
 ]
 
 [

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 locals_without_parens = [
+  assert_state: 1,
   assert_transition: 5,
   assert_transition: 6
 ]

--- a/.iex.exs
+++ b/.iex.exs
@@ -1,4 +1,10 @@
-global_settings = "~/.iex.exs"
+global_settings = Path.expand("~/.iex.exs")
 if File.exists?(global_settings), do: Code.require_file(global_settings)
 
-alias Finitomata.{Manager, Supervisor}
+alias Finitomata.{Manager, Supervisor, Transition}
+alias Finitomata.Test.Log, as: L
+require L
+alias Finitomata.Test.Sequenced, as: S
+require S
+alias Finitomata.Test.Transition, as: T
+require T

--- a/lib/finitomata.ex
+++ b/lib/finitomata.ex
@@ -403,7 +403,7 @@ defmodule Finitomata do
     do: id |> fqn(target) |> GenServer.call({:responds?, event})
 
   @doc """
-  Returns supervision tree of `Finitomata`. The healthy tree has all three `pid`s.`
+  Returns supervision tree of `Finitomata`. The healthy tree has all three `pid`s.
   """
   @spec sup_tree(id()) :: [
           {:supervisor, nil | pid()},

--- a/lib/finitomata/errors.ex
+++ b/lib/finitomata/errors.ex
@@ -1,17 +1,22 @@
 defmodule Finitomata.TestTransitionError do
-  defexception path: nil, transition: nil, missing_states: [], unknown_states: [], message: nil
+  defexception path: nil, transition: [], missing_states: [], unknown_states: [], message: nil
 
   @impl true
   def message(%{message: nil} = exception) do
-    Enum.join(
-      [
-        "The transition validation must include all possible continuations.",
-        "  Transition: " <> inspect(exception.transition) <> ".",
-        "  Missing states: " <> inspect(exception.missing_states) <> ".",
-        "  Unknown states: " <> inspect(exception.unknown_states) <> "."
-      ],
-      "\n"
-    )
+    [
+      "The transition validation must include all possible continuations.",
+      if(not Enum.empty?(exception.transition),
+        do: "  Transition: " <> inspect(exception.transition) <> "."
+      ),
+      if(not Enum.empty?(exception.missing_states),
+        do: "  Missing states: " <> inspect(exception.missing_states) <> "."
+      ),
+      if(not Enum.empty?(exception.unknown_states),
+        do: "  Unknown states: " <> inspect(exception.unknown_states) <> "."
+      )
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join("\n")
   end
 
   def message(%{message: message}) do

--- a/lib/finitomata/errors.ex
+++ b/lib/finitomata/errors.ex
@@ -26,6 +26,6 @@ defmodule Finitomata.TestTransitionError do
 
   defp hint do
     "\nIf you do not want to validate anything after entering some states, use " <>
-      "`:state -> :ok` clause."
+      "`:state -> :ok` clause.\n"
   end
 end

--- a/lib/finitomata/errors.ex
+++ b/lib/finitomata/errors.ex
@@ -1,0 +1,31 @@
+defmodule Finitomata.TestTransitionError do
+  defexception path: nil, transition: nil, missing_states: [], unknown_states: [], message: nil
+
+  @impl true
+  def message(%{message: nil} = exception) do
+    Enum.join(
+      [
+        "The transition validation must include all possible continuations.",
+        "  Transition: " <> inspect(exception.transition) <> ".",
+        "  Missing states: " <> inspect(exception.missing_states) <> ".",
+        "  Unknown states: " <> inspect(exception.unknown_states) <> "."
+      ],
+      "\n"
+    )
+  end
+
+  def message(%{message: message}) do
+    message
+  end
+
+  @impl true
+  def blame(exception, stacktrace) do
+    message = message(exception) <> hint()
+    {%{exception | message: message}, stacktrace}
+  end
+
+  defp hint do
+    "\nIf you do not want to validate anything after entering some states, use " <>
+      "`:state -> :ok` clause."
+  end
+end

--- a/lib/finitomata/test/ex_unit.ex
+++ b/lib/finitomata/test/ex_unit.ex
@@ -368,13 +368,18 @@ defmodule Finitomata.ExUnit do
     end
   end
 
+  @doc """
+  Convenience macro to test the whole _Finitomata_ path,
+    from starting to ending state.
+
+  Must be used with a `setup_finitomata/1` callback.
+  """
   defmacro test_path(test_name, ctx \\ quote(do: _), do: block) do
     quote generated: true, location: :keep do
       test unquote(test_name), unquote(ctx) = ctx do
         fsm =
           case ctx do
             %{finitomata: %{fsm: fsm}} ->
-              IO.inspect(fsm.implementation.__config__(:paths), label: "PATHS")
               fsm
 
             other ->
@@ -420,6 +425,7 @@ defmodule Finitomata.ExUnit do
     end
   end
 
+  @doc false
   defmacro test_path_transitions(id, impl, name, do: block) do
     block
     |> unblock()
@@ -431,13 +437,10 @@ defmodule Finitomata.ExUnit do
           {:->, meta, [[state], {:__block__, meta, unblock(block)}]}
         end)
 
-      do_assert_transition(id, impl, name, event_payload, do: state_assertions_ast)
+      {event_payload,
+       do_assert_transition(id, impl, name, event_payload, do: state_assertions_ast)}
     end)
   end
-
-  # defp escape(contents) do
-  #   Macro.escape(contents, unquote: true)
-  # end
 
   defp event_name({event, _payload}) when is_atom(event), do: event
   defp event_name(event) when is_atom(event), do: event

--- a/lib/finitomata/test/ex_unit.ex
+++ b/lib/finitomata/test/ex_unit.ex
@@ -368,9 +368,9 @@ defmodule Finitomata.ExUnit do
     end
   end
 
-  defmacro test_path(test_name, _ctx \\ quote(do: _), do: block) do
+  defmacro test_path(test_name, ctx \\ quote(do: _), do: block) do
     quote generated: true, location: :keep do
-      test unquote(test_name), ctx do
+      test unquote(test_name), unquote(ctx) = ctx do
         fsm =
           case ctx do
             %{finitomata: %{fsm: fsm}} ->

--- a/lib/finitomata/test/ex_unit.ex
+++ b/lib/finitomata/test/ex_unit.ex
@@ -373,6 +373,31 @@ defmodule Finitomata.ExUnit do
     from starting to ending state.
 
   Must be used with a `setup_finitomata/1` callback.
+
+  _Example:_
+
+  ```elixir
+    test_path "The only path", %{finitomata: %{test_pid: parent}} do
+      {:start, self()} ->
+        assert_state :started do
+          assert_payload do
+            internals.counter ~> 1
+            pid ~> ^parent
+          end
+
+          assert_receive {:on_start, ^parent}
+        end
+
+      :do ->
+        assert_state :done do
+          assert_receive :on_do
+        end
+
+        assert_state :* do
+          assert_receive :on_end
+        end
+    end
+  ```
   """
   defmacro test_path(test_name, ctx \\ quote(do: _), do: block) do
     quote generated: true, location: :keep do

--- a/mix.exs
+++ b/mix.exs
@@ -45,6 +45,7 @@ defmodule Finitomata.MixProject do
       # {:mox, "~> 1.0", only: [:dev, :test, :ci]},
       {:mox, git: "https://github.com/dashbitco/mox", only: [:dev, :test, :ci]},
       {:stream_data, "~> 0.5", only: [:dev, :test, :ci]},
+      {:observer_cli, "~> 1.5", only: [:dev]},
       {:credo, "~> 1.0", only: [:dev, :ci]},
       {:dialyxir, "~> 1.0", only: [:dev, :ci], runtime: false},
       {:ex_doc, "~> 0.11", only: [:dev]}

--- a/mix.lock
+++ b/mix.lock
@@ -14,5 +14,7 @@
   "mox": {:git, "https://github.com/dashbitco/mox", "a59a1840676ceb0ef6c3e0f4959242ccb5d593ab", []},
   "nimble_options": {:hex, :nimble_options, "1.0.1", "b448018287b22584e91b5fd9c6c0ad717cb4bcdaa457957c8d57770f56625c43", [:mix], [], "hexpm", "078b2927cd9f84555be6386d56e849b0c555025ecccf7afee00ab6a9e6f63837"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.3.0", "9e18a119d9efc3370a3ef2a937bf0b24c088d9c4bf0ba9d7c3751d49d347d035", [:mix], [], "hexpm", "7977f183127a7cbe9346981e2f480dc04c55ffddaef746bd58debd566070eef8"},
+  "observer_cli": {:hex, :observer_cli, "1.7.4", "3c1bfb6d91bf68f6a3d15f46ae20da0f7740d363ee5bc041191ce8722a6c4fae", [:mix, :rebar3], [{:recon, "~> 2.5.1", [hex: :recon, repo: "hexpm", optional: false]}], "hexpm", "50de6d95d814f447458bd5d72666a74624eddb0ef98bdcee61a0153aae0865ff"},
+  "recon": {:hex, :recon, "2.5.3", "739107b9050ea683c30e96de050bc59248fd27ec147696f79a8797ff9fa17153", [:mix, :rebar3], [], "hexpm", "6c6683f46fd4a1dfd98404b9f78dcabc7fcd8826613a89dcb984727a8c3099d7"},
   "stream_data": {:hex, :stream_data, "0.5.0", "b27641e58941685c75b353577dc602c9d2c12292dd84babf506c2033cd97893e", [:mix], [], "hexpm", "012bd2eec069ada4db3411f9115ccafa38540a3c78c4c0349f151fc761b9e271"},
 }

--- a/test/finitomata/ex_unit_test.exs
+++ b/test/finitomata/ex_unit_test.exs
@@ -101,7 +101,6 @@ defmodule Finitomata.ExUnit.Test do
     end
 
     _ = """
-    test_path "The only path" do
     """
 
     test_path "Test Path Test",
@@ -110,6 +109,7 @@ defmodule Finitomata.ExUnit.Test do
               "TestPathAssertionFSM",
               FTL.cast!(%{internals: %{counter: 0}, pid: self()}),
               parent: self() do
+      # test_path "The only path", %{finitomata: %{test_pid: parent}} do
       {:start, self()} ->
         assert_state :started do
           assert_payload do

--- a/test/finitomata/ex_unit_test.exs
+++ b/test/finitomata/ex_unit_test.exs
@@ -101,15 +101,15 @@ defmodule Finitomata.ExUnit.Test do
     end
 
     _ = """
+    test_path "The only path" do
+    """
+
     test_path "Test Path Test",
               Case,
               FTL,
               "TestPathAssertionFSM",
               FTL.cast!(%{internals: %{counter: 0}, pid: self()}),
               parent: self() do
-    """
-
-    test_path "The only path" do
       {:start, self()} ->
         assert_state :started do
           assert_payload do

--- a/test/finitomata/ex_unit_test.exs
+++ b/test/finitomata/ex_unit_test.exs
@@ -100,12 +100,16 @@ defmodule Finitomata.ExUnit.Test do
       end
     end
 
+    _ = """
     test_path "Test Path Test",
               Case,
               FTL,
               "TestPathAssertionFSM",
               FTL.cast!(%{internals: %{counter: 0}, pid: self()}),
               parent: self() do
+    """
+
+    test_path "The only path" do
       {:start, self()} ->
         assert_state :started do
           assert_payload do

--- a/test/finitomata/ex_unit_test.exs
+++ b/test/finitomata/ex_unit_test.exs
@@ -101,24 +101,22 @@ defmodule Finitomata.ExUnit.Test do
     end
 
     _ = """
-    """
-
     test_path "Test Path Test",
               Case,
               FTL,
               "TestPathAssertionFSM",
               FTL.cast!(%{internals: %{counter: 0}, pid: self()}),
               parent: self() do
-      # test_path "The only path", %{finitomata: %{test_pid: parent}} do
+    """
+
+    test_path "The only path", %{finitomata: %{test_pid: parent}} do
       {:start, self()} ->
         assert_state :started do
           assert_payload do
             internals.counter ~> 1
             pid ~> ^parent
-            # pid ~> context(:__pid__)
           end
 
-          # assert_receive {:on_start, context(:__pid__)}
           assert_receive {:on_start, ^parent}
         end
 

--- a/test/finitomata/ex_unit_test.exs
+++ b/test/finitomata/ex_unit_test.exs
@@ -1,0 +1,112 @@
+defmodule Finitomata.ExUnit.Test do
+  use ExUnit.Case
+
+  use ExUnitProperties
+  import Mox
+  import Finitomata.ExUnit
+
+  alias Finitomata.Test.Listener, as: FTL
+
+  test "standard approach" do
+    start_supervised(Finitomata.Supervisor)
+
+    check all fini_name <- StreamData.string(:alphanumeric, min_length: 16),
+              _fini_payload <-
+                StreamData.one_of([StreamData.atom(:alphanumeric), StreamData.integer(1..100)]),
+              max_runs: 50 do
+      fsm_name = {:via, Registry, {Finitomata.Registry, fini_name}}
+      parent = self()
+
+      FTL.Mox
+      |> allow(parent, fn -> GenServer.whereis(fsm_name) end)
+      |> expect(:after_transition, 4, fn id, state, payload ->
+        parent |> send({:on_transition, id, state, payload}) |> then(fn _ -> :ok end)
+      end)
+
+      Finitomata.start_fsm(FTL, fini_name, %FTL{})
+
+      assert_receive {:on_transition, ^fsm_name, :idle, %{internals: %{counter: 0}}}
+
+      Finitomata.transition(fini_name, {:start, parent})
+      assert_receive {:on_start, ^parent}
+      assert_receive {:on_transition, ^fsm_name, :started, %{pid: ^parent}}
+
+      Finitomata.transition(fini_name, :do)
+      assert_receive :on_do
+      assert_receive {:on_transition, ^fsm_name, :done, %{pid: ^parent}}
+
+      assert_receive :on_end
+      assert_receive {:on_transition, ^fsm_name, :*, %{pid: ^parent}}
+    end
+  end
+
+  describe "custom assertions" do
+    setup_finitomata do
+      parent = self()
+
+      [
+        fsm: [
+          id: Case,
+          implementation: FTL,
+          name: "AssertionFSM",
+          payload: FTL.cast!(%{internals: %{counter: 0}})
+        ],
+        context: [
+          parent: parent
+        ]
+      ]
+    end
+
+    test "low level with assert_transition", _ctx do
+      parent = self()
+
+      assert_transition Case, FTL, "AssertionFSM", {:start, parent} do
+        :started ->
+          assert_payload do: internals.counter ~> 1
+          assert_receive {:on_start, ^parent}
+      end
+
+      assert_transition Case, FTL, "AssertionFSM", {:do, nil} do
+        :done ->
+          assert_payload do
+            internals.counter ~> 2
+            pid ~> ^parent
+          end
+
+          assert_receive :on_do
+
+        :* ->
+          assert_receive :on_end
+          assert_payload %{internals: %{counter: 2}, pid: ^parent}
+      end
+    end
+
+    test_path "Test Path Test",
+              Case,
+              FTL,
+              "TestPathAssertionFSM",
+              FTL.cast!(%{internals: %{counter: 0}, pid: self()}),
+              parent: self() do
+      {:start, self()} ->
+        assert_state :started do
+          assert_payload do
+            internals.counter ~> 1
+            pid ~> ^parent
+            # pid ~> context(:__pid__)
+          end
+
+          # assert_receive {:on_start, context(:__pid__)}
+          assert_receive {:on_start, ^parent}
+        end
+
+      :do ->
+        assert_state :done do
+          assert_receive :on_do
+        end
+
+        assert_state :* do
+          assert_receive :on_end
+        end
+    end
+  end
+end

--- a/test/finitomata_test.exs
+++ b/test/finitomata_test.exs
@@ -241,26 +241,25 @@ defmodule Finitomata.Test do
 
     assert_transition Case, FTL, "AssertionFSM", {:start, 42} do
       :started ->
-        internals.pid ~> ^parent
+        assert_state do: internals.pid ~> ^parent
+        assert_receive {:on_start, 42}
     end
 
-    assert_receive {:on_start, 42}
     # assert_receive {:on_transition, ^fsm_name, :started, %{internals: %{pid: ^parent}}}
 
     assert_transition Case, FTL, "AssertionFSM", {:do, nil} do
       :done ->
-        internals.pid ~> ^parent
-        pid ~> ^parent
+        assert_state do
+          internals.pid ~> ^parent
+          pid ~> ^parent
+        end
+
+        assert_receive :on_do
 
       :* ->
-        :ok
+        assert_state %{pid: ^parent}
+        assert_receive :on_end
     end
-
-    assert_receive :on_do
-    # assert_receive {:on_transition, ^fsm_name, :done, %{internals: %{pid: ^parent}}}
-
-    assert_receive :on_end
-    # assert_receive {:on_transition, ^fsm_name, :*, %{internals: %{pid: ^parent}}}
   end
 
   test_path Case, FTL, "AssertionFSM" do

--- a/test/support/listener.ex
+++ b/test/support/listener.ex
@@ -10,7 +10,10 @@ defmodule Finitomata.Test.Listener do
 
   use Finitomata, fsm: @fsm, auto_terminate: true, listener: Finitomata.Test.Listener.Mox
 
-  defstate(%{internals: %{pid: {StreamData, :constant, [self()]}}})
+  defstate(%{
+    pid: {StreamData, :constant, [self()]},
+    internals: %{pid: {StreamData, :constant, [self()]}}
+  })
 
   @impl Finitomata
   def on_start(%{internals: %{pid: _pid}}), do: :ignore

--- a/test/support/modules.ex
+++ b/test/support/modules.ex
@@ -43,6 +43,20 @@ defmodule Finitomata.Test.Transition do
   use Finitomata, fsm: @fsm
 end
 
+defmodule Finitomata.Test.Sequenced do
+  @moduledoc false
+
+  @fsm """
+  idle --> |start| started
+  started --> |accept!| accepted
+  accepted --> |reject!| rejected
+  rejected --> |end| done
+  done --> |end!| ended
+  """
+
+  use Finitomata, fsm: @fsm
+end
+
 defmodule Finitomata.Test.Log do
   @moduledoc false
 


### PR DESCRIPTION
This is a not-yet-stable version of better testing, partially closing #45.

  ```elixir
    test_path "The only path", %{finitomata: %{test_pid: parent}} do
      {:start, self()} ->
        assert_state :started do
          assert_payload do
            internals.counter ~> 1
            pid ~> ^parent
          end

          assert_receive {:on_start, ^parent}
        end

      :do ->
        assert_state :done do
          assert_receive :on_do
        end

        assert_state :* do
          assert_receive :on_end
        end
    end
  ```
